### PR TITLE
[2025-10-24] nginx-proxy 이미지 없이 docker compose 를 활용하여 직접 MSA 구성

### DIFF
--- a/dcompose/compose/manual_lb/compose.yaml
+++ b/dcompose/compose/manual_lb/compose.yaml
@@ -1,0 +1,35 @@
+version: '3.8'
+name: awsgoo
+services:
+  nginx-proxy:
+    build: ../../docker_file/nginx
+    ports:
+      - "9889:80"
+    depends_on:
+      - blog
+    deploy:
+      resources:
+        limits:
+          cpus: '0.20'
+          memory: 50M
+        reservations:
+          cpus: '0.05'
+          memory: 20M
+
+  blog:
+    build: ../../docker_file/httpd
+    deploy:
+      mode: replicated
+      replicas: 1 # https://docs.docker.com/compose/compose-file/deploy/#replicas
+      resources: # https://docs.docker.com/compose/compose-file/compose-file-v3/#resources
+        limits:
+          cpus: '0.05'
+          memory: 50M
+        reservations:
+          cpus: '0.01'
+          memory: 20M
+    expose:
+      - "80"
+    environment:
+      - VIRTUAL_HOST=aws.google.com,172.31.86.218,ec2-54-236-8-204.compute-1.amazonaws.com
+      - VIRTUAL_PORT=80

--- a/dcompose/docker_file/nginx/default.conf
+++ b/dcompose/docker_file/nginx/default.conf
@@ -1,6 +1,6 @@
 upstream blog_servs{
-	server myblog-1:80;
-	 server myblog-2:80;
+	server awsgoo-blog-1:80;
+	# server myblog-2:80;
 	# server myblog-3:80;
 }
 


### PR DESCRIPTION
## 목표
nginx-proxy 이미지 없이 docker compose 를 활용하여 직접 MSA 구성한다.
## 과정
### docker compose 구성
1. 기존 docker compose 을 복사하기
```bash
cp compose.yaml ../manual_lb/
```

2. docker compose 파일 수정
``` yaml
version: '3.8'
name: awsgoo
services:
  nginx-proxy:
    # image: nginx/nginx-proxy: 기존 이미지 제거
    build: ../../docker_file/nginx
    # volumes: 도커 데몬과 통신할 수 있는 소켓 마운트 X -> 내가 직접 만든 이미지는 docker gen 의 프로그램이 없기 때문에 필요 없음
    #   - /var/run/docker.sock:/tmp/docker.sock:ro
    ports:
      - "9889:80"
    depends_on:
      - blog
    deploy:
      resources:
        limits:
          cpus: '0.20'
          memory: 50M
        reservations:
          cpus: '0.05'
          memory: 20M

  blog:
    build: ../../docker_file/httpd
    deploy:
      mode: replicated
      replicas: 1 # https://docs.docker.com/compose/compose-file/deploy/#replicas
      resources: # https://docs.docker.com/compose/compose-file/compose-file-v3/#resources
        limits:
          cpus: '0.05'
          memory: 50M
        reservations:
          cpus: '0.01'
          memory: 20M
    expose:
      - "80"
    environment:
      - VIRTUAL_HOST=aws.google.com,172.31.86.218,ec2-54-236-8-204.compute-1.amazonaws.com
      - VIRTUAL_PORT=80
```
### nginx 설정 변경
nginx 설정 파일 default.conf 에서 컨테이너 주소 변경(컨테이너 이름일 달라졌으므로 이름을 변경한다.)


### docker compose 으로 컨테이너 구동
```bash
docker compose -f compose.yaml up -d
```

<img width="1710" height="986" alt="image" src="https://github.com/user-attachments/assets/ddf4f8a6-4c07-4abb-8dba-5a3da6e78d31" />

## 결론
기존 이미지 대신 직접 만든 nginx 이미지를 활용하여 docker compose 하여 msa 환경을 구성하였다. 기존 nginx-proxy 에는 docker-gen 프로그램이 있어 docker daemon으로 부터 이미지를 받아 뒷 단의 서비스의 replicas 변경되었을 때 자동으로 nginx 설정에 등록되었지만 내가 직접 만든 nginx 이미지에는 그런 기능이 존재하지 않아 불가능하다.

## 궁금즘